### PR TITLE
show reading supply posts at /reading-supply

### DIFF
--- a/components/reading-supply.tsx
+++ b/components/reading-supply.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react'
+
+export default function ReadingSupply() {
+  const [data, setData] = useState<any>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    setLoading(true)
+    fetch('/api/rs')
+      .then((res) => res.json())
+      .then((data) => {
+        const result = []
+        for (var i in data.posts) {
+          result.push([i, data[i]])
+        }
+        setData(result)
+        setLoading(false)
+      })
+  }, [])
+
+  console.log({data})
+  console.log('typeof.data', typeof data)
+
+  return (
+    loading ? <div>Loading...</div> :
+    <div>
+      {data && data.map((post :any) => {
+        return (
+          <div key={post[0]}>
+            <div>{post[0]}</div>
+            <div>{post.url}</div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/pages/api/rs.ts
+++ b/pages/api/rs.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+// eslint-disable-next-line import/no-anonymous-default-export
+export default async (
+  _req: NextApiRequest,
+  res: NextApiResponse
+) => {
+  const key = process.env.READING_SUPPLY_API_KEY
+  const response = await fetch('https://reading.supply/api/v1/library', {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${key}`,
+    },
+  });
+
+  const json = await response.json()
+
+  res.status(200).json(json)
+}

--- a/pages/reading-supply/index.tsx
+++ b/pages/reading-supply/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import ReadingSupply from '../../components/reading-supply'
+
+export default function Index() {
+  return (
+    <ReadingSupply/>
+  )
+}


### PR DESCRIPTION
- show reading supply post ids at `/reading-supply` route

![CleanShot 2023-02-20 at 10 54 20](https://user-images.githubusercontent.com/1177031/220197194-abf911ca-1e62-49c8-9ac6-b54167d64649.gif)
